### PR TITLE
Signal spline

### DIFF
--- a/lalinference/src/LALInference.c
+++ b/lalinference/src/LALInference.c
@@ -4013,6 +4013,91 @@ int LALInferenceSplineCalibrationFactor(REAL8Vector *logfreqs,
   }
 }
 
+int LALInferenceSplineSignalFactor(REAL8Vector *logfreqs,
+				   REAL8Vector *deltaAmps,
+				   REAL8Vector *deltaPhases,
+				   COMPLEX16FrequencySeries *calFactor) {
+  size_t i = 0;
+  gsl_interp_accel *ampAcc = NULL, *phaseAcc = NULL;
+  gsl_interp *ampInterp = NULL, *phaseInterp = NULL;
+
+  int status = XLAL_SUCCESS;
+  const char *fmt = "";
+
+  size_t N = 0;
+
+  if (logfreqs == NULL || deltaAmps == NULL || deltaPhases == NULL || calFactor == NULL) {
+    status = XLAL_EINVAL;
+    fmt = "bad input";
+    goto cleanup;
+  }
+
+  if (logfreqs->length != deltaAmps->length || deltaAmps->length != deltaPhases->length) {
+    status = XLAL_EINVAL;
+    fmt = "input lengths differ";
+    goto cleanup;
+  }
+
+  N = logfreqs->length;
+
+  ampInterp = gsl_interp_alloc(gsl_interp_cspline, N);
+  phaseInterp = gsl_interp_alloc(gsl_interp_cspline, N);
+
+  if (ampInterp == NULL || phaseInterp == NULL) {
+    status = XLAL_ENOMEM;
+    fmt = "could not allocate GSL interpolation objects";
+    goto cleanup;
+  }
+
+  ampAcc = gsl_interp_accel_alloc();
+  phaseAcc = gsl_interp_accel_alloc();
+
+  if (ampAcc == NULL || phaseAcc == NULL) {
+    status = XLAL_ENOMEM;
+    fmt = "could not allocate interpolation acceleration objects";
+    goto cleanup;
+  }
+
+  gsl_interp_init(ampInterp, logfreqs->data, deltaAmps->data, N);
+  gsl_interp_init(phaseInterp, logfreqs->data, deltaPhases->data, N);
+
+  REAL8 lowf = exp(logfreqs->data[0]);
+  REAL8 highf = exp(logfreqs->data[N-1]);
+  COMPLEX16 Phi = 1.0;
+  for (i = 0; i < calFactor->data->length; i++) {
+    REAL8 dA = 0.0, dPhi = 0.0;
+    REAL8 f = calFactor->deltaF*i;
+
+    if (f < lowf || f > highf) {
+      dA = 0.0;
+      dPhi = 0.0;
+    } else {
+      dA = gsl_interp_eval(ampInterp, logfreqs->data, deltaAmps->data, log(f), ampAcc);
+      dPhi = gsl_interp_eval(phaseInterp, logfreqs->data, deltaPhases->data, log(f), phaseAcc);
+    }
+
+    /* f dPhi/df = <spline> => dPhi = <spline> * dF / f */
+
+    dPhi = dPhi * calFactor->deltaF / f;
+    
+    Phi = Phi * (2.0 + I*dPhi) / (2.0 - I*dPhi);
+    
+    calFactor->data->data[i] = (1.0 + dA)*Phi;
+  }
+
+ cleanup:
+  if (ampInterp != NULL) gsl_interp_free(ampInterp);
+  if (phaseInterp != NULL) gsl_interp_free(phaseInterp);
+  if (ampAcc != NULL) gsl_interp_accel_free(ampAcc);
+  if (phaseAcc != NULL) gsl_interp_accel_free(phaseAcc);
+
+  if (status == XLAL_SUCCESS) {
+    return status;
+  } else {
+    XLAL_ERROR(status, "%s", fmt);
+  }
+}
+
 int LALInferenceSplineCalibrationFactorROQ(REAL8Vector *logfreqs,
 					REAL8Vector *deltaAmps,
 					REAL8Vector *deltaPhases,

--- a/lalinference/src/LALInference.h
+++ b/lalinference/src/LALInference.h
@@ -357,6 +357,21 @@ int LALInferenceSplineCalibrationFactor(REAL8Vector *freqs,
 					REAL8Vector *deltaPhases,
 					COMPLEX16FrequencySeries *calFactor);
 
+/** Computes the spline factor for the signal spline model.  In the
+    signal spline model, the amplitude and phase adjustment is shared
+    (i.e. common-mode) across all IFOs.  The amplitude adjustment is
+    the same as in the calibration spline model, but the phase
+    offset's derivative is set by the spline
+    \f[
+      \frac{\mathrm{d} \Psi}{\mathrm{d} \log f} = \mathrm{Spline}
+    \f]
+
+ */
+int LALInferenceSplineSignalFactor(REAL8Vector *freqs,
+				   REAL8Vector *deltaAmps,
+				   REAL8Vector *deltaPhases,
+				   COMPLEX16FrequencySeries *calFactor);
+
  /** Modified version of LALInferenceSplineCalibrationFactor to compute the 
  *	calibration factors for the specific frequency nodes used for 
  *	Reduced Order Quadrature likelihoods.

--- a/lalinference/src/LALInferenceInitCBC.c
+++ b/lalinference/src/LALInferenceInitCBC.c
@@ -677,8 +677,8 @@ void LALInferenceInitSpSignalVariables(LALInferenceRunState *runState, LALInfere
   REAL8 dist_to_ref_freq = INFINITY;
   UINT4 i_ref = 0;
   for(i=0;i<npts;i++) {
-      REAL8 freq_dist = ref_freq - exp(logFMin + i*dLogF);
-    if (freq_dist > 0 && freq_dist < dist_to_ref_freq) {
+      REAL8 freq_dist = fabs(exp(logFMin + i*dLogF) - ref_freq);
+    if (freq_dist < dist_to_ref_freq) {
         dist_to_ref_freq = freq_dist;
         i_ref = i;
     }
@@ -703,7 +703,7 @@ void LALInferenceInitSpSignalVariables(LALInferenceRunState *runState, LALInfere
           }
 
           /* Fix the first point so that all other deviations are relative to that frequency */
-          if (i==i_ref || i==i_ref+1) {
+          if (i==i_ref) {
               LALInferenceAddREAL8Variable(currentParams, ampVarName, 0, LALINFERENCE_PARAM_FIXED);
               LALInferenceAddREAL8Variable(currentParams, phaseVarName, 0, LALINFERENCE_PARAM_FIXED);
           } else {

--- a/lalinference/src/LALInferenceInitCBC.c
+++ b/lalinference/src/LALInferenceInitCBC.c
@@ -702,10 +702,13 @@ void LALInferenceInitSpSignalVariables(LALInferenceRunState *runState, LALInfere
                   phase_mean = gsl_spline_eval(env->phase_std, logFreq, NULL);
           }
 
-          /* Fix the first point so that all other deviations are relative to that frequency */
+          /* Fix the reference point so that all other deviations in
+	     amplitude are relative to that frequency; since the
+	     spline model for the phase already has a derivative in
+	     it, we don't need to fix it. */
           if (i==i_ref) {
               LALInferenceAddREAL8Variable(currentParams, ampVarName, 0, LALINFERENCE_PARAM_FIXED);
-              LALInferenceAddREAL8Variable(currentParams, phaseVarName, 0, LALINFERENCE_PARAM_FIXED);
+              LALInferenceAddREAL8Variable(currentParams, phaseVarName, 0, LALINFERENCE_PARAM_LINEAR);
           } else {
               LALInferenceRegisterGaussianVariableREAL8(runState, currentParams, ampVarName, 0, amp_mean, amp_std, LALINFERENCE_PARAM_LINEAR);
               LALInferenceRegisterGaussianVariableREAL8(runState, currentParams, phaseVarName, 0, phase_mean, phase_std, LALINFERENCE_PARAM_LINEAR);

--- a/lalinference/src/LALInferenceLikelihood.c
+++ b/lalinference/src/LALInferenceLikelihood.c
@@ -704,7 +704,7 @@ static REAL8 LALInferenceFusedFreqDomainLogLikelihood(LALInferenceVariables *cur
                        &lalDimensionlessUnit,
                        dataPtr->freqData->data->length);
         }
-        LALInferenceSplineCalibrationFactor(logfreqs, amps, phases, sigFactor);
+        LALInferenceSplineSignalFactor(logfreqs, amps, phases, sigFactor);
 	}
         if(logfreqs) XLALDestroyREAL8Vector(logfreqs);
         if(amps) XLALDestroyREAL8Vector(amps);


### PR DESCRIPTION
@bfarr I finally implemented the different model.  The new model is that 

d(Phi)/d(log(f)) = <spline(f)>

so the spline gives the *derivative* of the phase rather than the phase.  Thus, sensible priors will have a width in the phase part that is O(2*pi) (so that 2*pi of phase accumulates per log(f)).  I haven't really tested it, but the change is pretty simple; can you sanity check (i.e. read the patch), and then try it out?